### PR TITLE
fix: ensure tests will pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
+          cache: 'maven'
 
       - name: Run install
         # Skip tests because we require the install before the publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         java: [ '8' ]
         os: [ 'ubuntu-latest', 'macOS-latest' ]
@@ -29,4 +30,9 @@ jobs:
           java-version: ${{ matrix.java }}
 
       - name: Run install
-        run: ./mvnw install
+        # Skip tests because we require the install before the publish
+        # we'll then test right after
+        run: ./mvnw clean install -DskipTests
+
+      - name: Run tests
+        run: ./mvnw test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '8' ]
+        java: [ '8', '17' ]
         os: [ 'ubuntu-latest', 'macOS-latest' ]
 
     steps:


### PR DESCRIPTION
We make sure we use `-DskipTests` during install to make sure it installs
first, and then we run tests after
