### PR TITLE
deps: bump maven related deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,8 @@
     <nexus.url>https://oss.sonatype.org</nexus.url>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <version.maven.base>3.8.6</version.maven.base>
+    <version.maven.plugin.plugin>3.7.0</version.maven.plugin.plugin>
   </properties>
 
   <scm>
@@ -75,7 +77,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.6.1</version>
+          <version>${version.maven.plugin.plugin}</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -148,24 +150,31 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>3.6.1</version>
+      <version>${version.maven.base}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.6.1</version>
-      <!--
-        I believe this should be provided as well, but currently it's not in the last version.
-        This is probably due to things breaking if you bump up since the mojo scanner isn't compatible
-        so we'll need some changes to bump this or to make this provided.
-      -->
-      <!--<scope>provided</scope>-->
+      <version>${version.maven.base}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+      <version>${version.maven.base}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>${version.maven.base}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.5</version>
+      <version>${version.maven.plugin.plugin}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
I'm going to manually test this on a few repos locally, but this fixes
the issue with the Maven api not being marked as provided. Once you bump
the plugin-plugin deps it actually yells pretty loud at you if you don't
do this, so I wanted to ensure we could. This ensures that Maven is on
the latest and also the maven plugin plugin tools.