### PR TITLE
Various fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run install
         # Skip tests because we require the install before the publish
         # we'll then test right after
-        run: ./mvnw clean install -DskipTests
+        run: mvn clean install -DskipTests
 
       - name: Run tests
-        run: ./mvnw test
+        run: mvn test

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bloop/
 target/
 release.properties
+bloop.properties

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   <inceptionYear>2017</inceptionYear>
 
   <properties>
+    <version>${project.version}</version>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
     <nexus.url>https://oss.sonatype.org</nexus.url>
@@ -31,12 +32,12 @@
 
   <ciManagement>
     <system>GitHub Actions</system>
-    <url>https://github.com/scalacenter/maven-bloop/actions</url>
+    <url>https://github.com/scalacenter/bloop-maven-plugin/actions</url>
   </ciManagement>
 
   <issueManagement>
     <system>GitHub</system>
-    <url>https://github.com/scalacenter/maven-bloop/issues</url>
+    <url>https://github.com/scalacenter/bloop-maven-plugin/issues</url>
   </issueManagement>
 
   <distributionManagement>
@@ -95,6 +96,23 @@
               <goal>compile</goal>
               <goal>testCompile</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.1.0</version>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>write-project-properties</goal>
+            </goals>
+            <configuration>
+              <outputFile>./src/test/resources/bloop.properties</outputFile>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
               <goal>compile</goal>
               <goal>testCompile</goal>
             </goals>
+            <configuration>
+              <args>
+                <arg>-Wunused:imports</arg>
+              </args>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -192,7 +192,8 @@ object MojoImplementation {
           artifact.getGroupId()
       }
       .getOrElse("org.scala-lang")
-    val scalacArgs = mojo.getScalacArgs().asScala.toList.filter(_ != null)
+    val scalacArgs =
+      Try(mojo.getScalacArgs()).toOption.toList.map(_.asScala.toList).flatten.filter(_ != null)
 
     def writeConfig(
         sourceDirs0: Seq[File],

--- a/src/test/scala/bloop/integrations/maven/MavenConfigGenerationTest.scala
+++ b/src/test/scala/bloop/integrations/maven/MavenConfigGenerationTest.scala
@@ -17,6 +17,10 @@ import bloop.config.Tag
 
 import org.junit.Assert._
 import org.junit.Test
+import java.util.Properties
+import scala.io.Source
+import java.io.InputStream
+import scala.io.BufferedSource
 
 class MavenConfigGenerationTest extends BaseConfigSuite {
 
@@ -257,8 +261,15 @@ class MavenConfigGenerationTest extends BaseConfigSuite {
       "-jar",
       wrapperJar.toString()
     )
+
+    val bloopProperties: InputStream = getClass().getResourceAsStream("/bloop.properties")
+
+    val properties = new Properties()
+    properties.load(bloopProperties)
+    val version = properties.get("version").asInstanceOf[String]
+
     val command =
-      List(s"ch.epfl.scala:bloop-maven-plugin:bloopInstall", "-DdownloadSources=true")
+      List(s"ch.epfl.scala:bloop-maven-plugin:$version:bloopInstall", "-DdownloadSources=true")
     val allArgs = List(
       javaArgs,
       jarArgs,

--- a/src/test/scala/bloop/integrations/maven/MavenConfigGenerationTest.scala
+++ b/src/test/scala/bloop/integrations/maven/MavenConfigGenerationTest.scala
@@ -18,9 +18,7 @@ import bloop.config.Tag
 import org.junit.Assert._
 import org.junit.Test
 import java.util.Properties
-import scala.io.Source
 import java.io.InputStream
-import scala.io.BufferedSource
 
 class MavenConfigGenerationTest extends BaseConfigSuite {
 


### PR DESCRIPTION
There was a change I didn't catch in the previous pr due to how I was
testing. I wasn't being explicit about the version when running
`bloopInstall` so it was using the last published version. This fixes
that by using the version that is inside of the pom when you test.

The other issue, which the title is about, is that
`mojo.getScalacArgs()` can throw now since it attempts to get the scala
version set for the module. However, in Java modules there isn't one, so
this was blowing up. This fixes that by wrapping that call like we
earlier for other calls that can throw.

This also fixes some pom settings that were still pointing to the old
repo.