### PR TITLE
chore: ignore scala updates

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,2 @@
+// We ignore updates to Scala since we need to align the version with the Scala Maven plugin
+updates.ignore = [ { groupId = "org.scala-lang" } ]


### PR DESCRIPTION
We need to align the version of Scala with the Maven plugin or else
it will complain. So we'll turn off Steward updates for this.

supercedes: https://github.com/scalacenter/bloop-maven-plugin/pull/34
