### PR TITLE
Fix launcher configuration

### DIFF
--- a/src/main/java/bloop/integrations/maven/BloopMojo.java
+++ b/src/main/java/bloop/integrations/maven/BloopMojo.java
@@ -85,6 +85,7 @@ public class BloopMojo extends ExtendedScalaContinuousCompileMojo {
     private ModuleType moduleType;
     private List<String> javaCompilerArgs;
 
+    @Parameter(property = "launchers")
     private AppLauncher[] launchers;
 
     @Parameter(property = "sourceDir", defaultValue = "$mainSourceDir")

--- a/src/main/java/scala_maven/AppLauncher.java
+++ b/src/main/java/scala_maven/AppLauncher.java
@@ -1,6 +1,13 @@
 package scala_maven;
 
 public class AppLauncher extends Launcher {
+    public AppLauncher() {
+        this.id = "";
+        this.mainClass = "";
+        this.jvmArgs = new String[0];
+        this.args = new String[0];
+    }
+
     public AppLauncher(String id, String mainClass, String[] jvmArgs, String[] args) {
         this.id = id;
         this.mainClass = mainClass;

--- a/src/main/java/scala_maven/AppLauncher.java
+++ b/src/main/java/scala_maven/AppLauncher.java
@@ -8,13 +8,6 @@ public class AppLauncher extends Launcher {
         this.args = new String[0];
     }
 
-    public AppLauncher(String id, String mainClass, String[] jvmArgs, String[] args) {
-        this.id = id;
-        this.mainClass = mainClass;
-        this.jvmArgs = jvmArgs;
-        this.args = args;
-    }
-
     public String getId() {
         return id;
     }

--- a/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -55,7 +55,7 @@ object MojoImplementation {
     }
 
     val currentConfig = mojoExecution.getConfiguration
-    val dom = newConfig.map(nc => Xpp3Dom.mergeXpp3Dom(currentConfig, nc))
+    val dom = newConfig.map(nc => Xpp3Dom.mergeXpp3Dom(nc, currentConfig))
     Try {
       dom.foreach(mojoExecution.setConfiguration)
       val mojo = mavenPluginManager
@@ -167,11 +167,13 @@ object MojoImplementation {
     val launchers = mojo.getLaunchers()
     val launcher = launchers
       .find(_.getId == launcherId)
+      .orElse {
+        if (launcherId.nonEmpty)
+          log.warn(s"Falling back to first launcher: Launcher ID '${launcherId}' does not exist")
+        launchers.headOption
+      }
       .getOrElse {
-        if (launchers.isEmpty)
-          log.info(s"Using empty launcher: no run setup for ${project.getName}.")
-        else if (launcherId.nonEmpty)
-          log.warn(s"Using empty launcher: Launcher ID '${launcherId}' does not exist")
+        log.info(s"Using empty launcher: no run setup for ${project.getName}.")
         emptyLauncher
       }
 

--- a/src/test/resources/launcher/pom.xml
+++ b/src/test/resources/launcher/pom.xml
@@ -1,0 +1,78 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>launcher</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>launcher</name>
+  <description>A minimal Scala project using the Maven build tool.</description>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <encoding>UTF-8</encoding>
+    <scala.version>2.13.12</scala.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+
+    <!-- Test -->
+    <dependency>
+      <groupId>org.scalameta</groupId>
+      <artifactId>munit_2.13</artifactId>
+      <version>0.7.29</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src/main/scala</sourceDirectory>
+    <testSourceDirectory>src/test/scala</testSourceDirectory>
+    <plugins>
+      <plugin>
+        <!-- see http://davidb.github.com/scala-maven-plugin -->
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>4.8.1</version>
+        <configuration>
+          <args>
+            <arg>test</arg>
+          </args>
+          <launcher>launcher-2</launcher>
+          <launchers>
+            <launcher>
+              <id>launcher-1</id>
+            </launcher>
+            <launcher>
+              <id>launcher-2</id>
+              <args>
+                <arg>--arg a</arg>
+                <arg>--arg b</arg>
+              </args>
+              <jvmArgs>
+                <jvmArg>--jvm-arg a</jvmArg>
+                <jvmArg>--jvm-arg b</jvmArg>
+              </jvmArgs>
+              <mainClass>com.example.Main</mainClass>
+            </launcher>
+          </launchers>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <args></args>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/launcher/pom.xml
+++ b/src/test/resources/launcher/pom.xml
@@ -39,9 +39,6 @@
         <artifactId>scala-maven-plugin</artifactId>
         <version>4.8.1</version>
         <configuration>
-          <args>
-            <arg>test</arg>
-          </args>
           <launcher>launcher-2</launcher>
           <launchers>
             <launcher>


### PR DESCRIPTION
Fixes #47

Overview:
- Add [empty default constructor](https://github.com/scalacenter/bloop-maven-plugin/pull/74/files#diff-f8eae362ed7d093b6e6b9c026c1dd40371212a83fd604c5fab8e183d0d835f57R4) to `AppLauncher` to prevent the `Cannot create instance of class` error
- Prefer [loaded config over default config](https://github.com/scalacenter/bloop-maven-plugin/pull/74/files#diff-93b3c07386db288973b02fbdca1d75e8291d9f7404500bec11c70ea12b3d5132R58) to correctly read the `launcher` configuration option
- Update [launcher selection logic](https://github.com/scalacenter/bloop-maven-plugin/pull/74/files#diff-93b3c07386db288973b02fbdca1d75e8291d9f7404500bec11c70ea12b3d5132R164) to be more [in line with scala-maven-plugin](https://github.com/davidB/scala-maven-plugin/blob/master/src/main/java/scala_maven/ScalaRunMojo.java#L86):
  - use the launcher specified by the `launcher` configuration option
  - if that doesn't exist or is not defined, fall back to the first launcher from the list of `launchers` in the configuration
    - for `scala-maven-plugin` the first launcher is used only if `launcher` is not defined (vs. also if it doesn't exist)
    - I added the fall back logic with a [new warning](https://github.com/scalacenter/bloop-maven-plugin/pull/74/files#diff-93b3c07386db288973b02fbdca1d75e8291d9f7404500bec11c70ea12b3d5132R170)
    - I can change the behavior to exactly mirror `scala-maven-plugin` if needed
- Refactor out `emptyLauncher` in favor of an `Option[AppLauncher]`
- Add [test case](https://github.com/scalacenter/bloop-maven-plugin/pull/74/files#diff-c666d9dc9ff2281846405b3b3c5549f867a92097326231f81f1db66dfbec031bR70) for launcher configuration