### PR TITLE
chore: Fix CI on MacOs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ '8', '17' ]
-        os: [ 'ubuntu-latest', 'macOS-latest' ]
+        os: [ 'ubuntu-latest', 'macOS-13' ]
 
     steps:
       - name: checkout the repo


### PR DESCRIPTION
Latest versions of the runners run on M1 and M2, which don't have JDK 8 available for them