### PR TITLE
Revert "[maven-release-plugin] prepare release bloop-maven-plugin-2.0.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>bloop-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
 
-  <version>2.0.1</version>
+  <version>2.0.1-SNAPSHOT</version>
   <name>Bloop Maven Plugin</name>
   <description>A Maven plugin which exports your Maven build into a format Bloop can understand.</description>
   <url>https://scalacenter.github.io/bloop/docs/build-tools/maven</url>
@@ -27,7 +27,7 @@
     <connection>scm:git:https://github.com/scalacenter/bloop-maven-plugin.git</connection>
     <developerConnection>scm:git:https://github.com/scalacenter/bloop-maven-plugin.git</developerConnection>
     <url>https://github.com/scalacenter/bloop-maven-plugin</url>
-    <tag>bloop-maven-plugin-2.0.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <ciManagement>


### PR DESCRIPTION
This reverts commit 2006c5881f87e38e7ada0b0000c5cb433d5ddd17.

The release failed.