### PR TITLE
Update bloop-config to 2.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
     <dependency>
       <groupId>ch.epfl.scala</groupId>
       <artifactId>bloop-config_2.13</artifactId>
-      <version>2.3.1</version>
+      <version>2.3.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Updating to the latest version of bloop config that adds support for TestNG tests.