### PR TITLE
Add automatic JUnit support by injecting junit-interface

### DIFF
--- a/src/test/resources/junit_project/pom.xml
+++ b/src/test/resources/junit_project/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>junit_project</artifactId>
+  <version>0.1</version>
+  <packaging>jar</packaging>
+  <name>junit_project</name>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>2.13.8</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/test/scala/bloop/integrations/maven/MavenConfigGenerationTest.scala
+++ b/src/test/scala/bloop/integrations/maven/MavenConfigGenerationTest.scala
@@ -261,6 +261,26 @@ class MavenConfigGenerationTest extends BaseConfigSuite {
     }
   }
 
+  @Test
+  def junitSupport() = {
+    check("junit_project/pom.xml") { (configFile, projectName, subprojects) =>
+      assert(subprojects.isEmpty)
+      
+      // Read the test configuration file
+      val testConfigFile = readValidBloopConfig(configFile.project.directory.resolve(".bloop").resolve(s"$projectName-test.json").toFile())
+      
+      // Check if junit-interface is present in the resolution modules of the test config
+      val resolutionModules = testConfigFile.project.resolution.get.modules
+      val hasJunitInterface = resolutionModules.exists(_.name.contains("junit-interface"))
+      
+      assertTrue("junit-interface should be present in test config when junit is used", hasJunitInterface)
+      
+      // Also check classpath
+      val hasJunitInterfaceInClasspath = testConfigFile.project.classpath.exists(_.toString.contains("junit-interface"))
+      assertTrue("junit-interface should be present in test classpath when junit is used", hasJunitInterfaceInClasspath)
+    }
+  }
+
   private def check(testProject: String, submodules: List[String] = Nil)(
       checking: (Config.File, String, List[Config.File]) => Unit
   ): Unit = {


### PR DESCRIPTION
This PR adds automatic support for JUnit tests in Maven projects that don't explicitly include the junit-interface dependency. Bloop requires junit-interface to run JUnit 4 tests. The plugin now detects if junit is present and junit-interface is missing, and automatically injects com.github.sbt:junit-interface:0.13.3 into the Bloop configuration.

## Changes:

- Modified MojoImplementation.scala to detect JUnit and inject `junit-interface` into the test configuration's classpath and resolution modules.

- Added a regression test `junitSupport` in MavenConfigGenerationTest.scala.

- Added a reproduction Maven project `junit_project` in `src/test/resources`.

## Verification:

Ran `./mvnw clean test` and verified that all 9 tests pass, including the new `junitSupport` test.

## Closing issue:

closes #28 

@tgodzik 