### PR TITLE
Fix: Correctly detect Scala version defined in maven-scala-plugin configuration

### DIFF
--- a/src/test/resources/issue_84/pom.xml
+++ b/src/test/resources/issue_84/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>bloop.test</groupId>
+  <artifactId>issue_84</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>issue-84-test</name>
+
+  <dependencies>
+      <dependency>
+          <groupId>org.scala-lang</groupId>
+          <artifactId>scala3-library_3</artifactId>
+          <version>3.2.2</version>
+      </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>4.9.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+               <scalaVersion>3.4.2</scalaVersion>
+               <scalaCompatVersion>3.4.2</scalaCompatVersion>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/scala/bloop/integrations/maven/MavenConfigGenerationTest.scala
+++ b/src/test/scala/bloop/integrations/maven/MavenConfigGenerationTest.scala
@@ -467,4 +467,12 @@ class MavenConfigGenerationTest extends BaseConfigSuite {
     }
   }
 
+  @Test
+  def issue84() = {
+    check("issue_84/pom.xml") { (configFile, projectName, subprojects) =>
+      assert(subprojects.isEmpty)
+      assert(configFile.project.`scala`.isDefined, "Scala config should be defined")
+      assertEquals("3.4.2", configFile.project.`scala`.get.version)
+    }
+  }
 }


### PR DESCRIPTION
## Problem: 

The `bloop-maven-plugin` failed to detect `scalaVersion` or `scalaCompatVersion` if these were defined within an `<execution>` block of the `scala-maven-plugin` (a common configuration pattern), causing it to fall back to the Scala version of the project's dependencies (e.g., sticking to 3.2.2 even if 3.4.2 was configured).

## Solution: 

Updated MojoImplementation.scala to inspect not only the top-level plugin configuration but also all `<execution>` configurations. These configurations are merged (Execution config > Plugin config) to ensure the specific execution settings are respected.

## Verification: 

Added a regression test `issue84` in MavenConfigGenerationTest.scala which reproduces the issue using a test project (`issue_84/pom.xml`) that defines the Scala version only in an execution block. The test passes and confirms the correct version (3.4.2) is detected.

## Fixing issue:

fixes #84 

@tgodzik 