### PR TITLE
Fix: Remove excluded modules from classpath

### DIFF
--- a/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -291,10 +291,18 @@ object MojoImplementation {
       val resolution = Some(Config.Resolution(modules))
 
       val (classpath, runtimeClasspath) = {
+        // keys of artifacts that survived Maven's exclusion resolution for this module.
+        val resolvedArtifactKeys: Set[String] = project.getArtifacts.asScala
+          .map(a => ArtifactUtils.versionlessKey(a))
+          .toSet
+
         val projectDependencies = dependencies.flatMap { d =>
-          val build = d.getBuild()
-          if (configuration == "compile") build.getOutputDirectory() :: Nil
-          else build.getTestOutputDirectory() :: build.getOutputDirectory() :: Nil
+          if (!resolvedArtifactKeys.contains(ArtifactUtils.versionlessKey(d.getArtifact))) Nil
+          else {
+            val build = d.getBuild()
+            if (configuration == "compile") build.getOutputDirectory() :: Nil
+            else build.getTestOutputDirectory() :: build.getOutputDirectory() :: Nil
+          }
         }
 
         val cp = classpath0().asScala.toList.asInstanceOf[List[String]].map(u => abs(new File(u)))

--- a/src/test/resources/exclusion/api/pom.xml
+++ b/src/test/resources/exclusion/api/pom.xml
@@ -1,0 +1,17 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>exclusion</artifactId>
+    <version>0.1</version>
+  </parent>
+  <artifactId>api</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>shims</artifactId>
+      <version>0.1</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/test/resources/exclusion/consumer/pom.xml
+++ b/src/test/resources/exclusion/consumer/pom.xml
@@ -1,0 +1,23 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>exclusion</artifactId>
+    <version>0.1</version>
+  </parent>
+  <artifactId>consumer</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>api</artifactId>
+      <version>0.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.example</groupId>
+          <artifactId>shims</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/test/resources/exclusion/pom.xml
+++ b/src/test/resources/exclusion/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>exclusion</artifactId>
+  <version>0.1</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>shims</module>
+    <module>api</module>
+    <module>consumer</module>
+  </modules>
+</project>

--- a/src/test/resources/exclusion/shims/pom.xml
+++ b/src/test/resources/exclusion/shims/pom.xml
@@ -1,0 +1,9 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>exclusion</artifactId>
+    <version>0.1</version>
+  </parent>
+  <artifactId>shims</artifactId>
+</project>

--- a/src/test/scala/bloop/integrations/maven/MavenConfigGenerationTest.scala
+++ b/src/test/scala/bloop/integrations/maven/MavenConfigGenerationTest.scala
@@ -545,6 +545,39 @@ class MavenConfigGenerationTest extends BaseConfigSuite {
   }
 
   @Test
+  def exclusion() = {
+    check(
+      "exclusion/pom.xml",
+      submodules = List(
+        "exclusion/shims/pom.xml",
+        "exclusion/api/pom.xml",
+        "exclusion/consumer/pom.xml"
+      )
+    ) {
+      case (_, _, List(_, apiConfig, consumerConfig)) =>
+        // api depends on shims — shims output dir must be on api's classpath
+        assert(
+          hasCompileClasspathEntryName(apiConfig, "shims"),
+          "api should have shims on its compile classpath"
+        )
+
+        // consumer explicitly excludes shims — its output dir must NOT appear
+        assert(
+          !hasCompileClasspathEntryName(consumerConfig, "shims"),
+          "consumer should not have shims on its compile classpath"
+        )
+
+        // api itself must still be on consumer's classpath
+        assert(
+          hasCompileClasspathEntryName(consumerConfig, "api"),
+          "consumer should still have api on its compile classpath"
+        )
+      case _ =>
+        assert(false, "exclusion should have exactly three submodules")
+    }
+  }
+
+  @Test
   def runtimeDependency() = {
     check("runtime_dependency/pom.xml") { (configFile, projectName, subprojects) =>
       assert(subprojects.isEmpty)


### PR DESCRIPTION
#### Problem (https://github.com/scalacenter/bloop-maven-plugin/issues/141)
When a Maven module declares an `<exclusion>` on a transitive dependency, the excluded module's compiled output directory still appears on the Bloop classpath. This causes compilation failures in projects that use exclusions to manage classpath conflicts. This problem is reproducible in Spark (See https://github.com/scalacenter/bloop-maven-plugin/issues/141 for details)

#### Solution
`MavenProject.getArtifacts()` returns the set of artifacts that survived Maven's full dependency resolution, including exclusion filtering. This PR uses this method as a gate before adding modules to the classpath. 

#### Test plan
- Added integration test
- Validated the fix against Spark
```bash
$ mvn generate-sources ch.epfl.scala:bloop-maven-plugin:2.0.2-SNAPSHOT:bloopInstall
$ bloop compile spark-catalyst_2.13
Compiling spark-catalyst_2.13 (655 Scala sources and 237 Java sources)
...
...
Compiled spark-catalyst_2.13 (18776ms)
```


closes https://github.com/scalacenter/bloop-maven-plugin/issues/141

cc: @tgodzik