### PR TITLE
Link dependents of shaded reactor modules to the shaded JAR instead of target/classes

### DIFF
--- a/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -29,6 +29,7 @@ import scala_maven.AppLauncher
 object MojoImplementation {
   private val ScalaMavenGroupArtifact = "net.alchim31.maven:scala-maven-plugin"
   private val JavaMavenGroupArtifact = "org.apache.maven.plugins:maven-compiler-plugin"
+  private val ShadeGroupArtifact = "org.apache.maven.plugins:maven-shade-plugin"
 
   def initializeMojo(
       project: MavenProject,
@@ -134,6 +135,65 @@ object MojoImplementation {
       }
     }
 
+    // A reactor module built by maven-shade-plugin rewrites/bundles its bytecode into the shaded
+    // JAR; those classes never land in target/classes. Dependents must therefore see the JAR, not
+    // the (empty) output directory. Returns the shaded JAR for such a module only when it replaces
+    // the module's main artifact AND exists on disk in this reactor build. Returns None when the
+    // module is not shaded, when shade attaches the shaded JAR as a secondary (classified) artifact
+    // (the main artifact stays unshaded, so target/classes is correct), or when the JAR has not been
+    // produced yet (shade binds to `package`, after this goal) — in which case it warns. We never
+    // resolve the module's GAV from a repository: that could wire a stale installed/released binary
+    // instead of the current build output.
+    def shadedJarOf(p: MavenProject): Option[File] = {
+      Option(p.getBuild.getPluginsAsMap.get(ShadeGroupArtifact))
+        // Only treat it as shade-built when an execution actually binds the `shade` goal; mere
+        // plugin/config presence (e.g. shared config, no bound execution) does not produce a JAR.
+        .filter(_.getExecutions.asScala.exists(_.getGoals.asScala.contains("shade")))
+        .flatMap { plugin =>
+        // Merge execution-level config (where the `shade` goal is usually bound) over plugin-level.
+        val pluginCfg = Option(plugin.getConfiguration).map(_.asInstanceOf[Xpp3Dom])
+        val execCfgs = plugin.getExecutions.asScala
+          .flatMap(e => Option(e.getConfiguration).map(_.asInstanceOf[Xpp3Dom]))
+        val cfg = (execCfgs ++ pluginCfg)
+          .reduceOption((dominant, recessive) => Xpp3Dom.mergeXpp3Dom(dominant, recessive))
+        def child(name: String): Option[String] =
+          cfg
+            .flatMap(d => Option(d.getChild(name)))
+            .flatMap(c => Option(c.getValue))
+            .map(_.trim)
+            .filter(_.nonEmpty)
+
+        val build = p.getBuild
+        def warnMissing(jar: File): Option[File] = {
+          log.warn(
+            s"Reactor module '${p.getArtifactId}' is built by maven-shade-plugin but its shaded " +
+              s"JAR was not found at $jar. Its relocated/bundled classes are NOT in target/classes, " +
+              s"so dependents will fail to compile. Run `mvn package` on '${p.getArtifactId}' " +
+              s"(shade binds to the package phase) before exporting to bloop."
+          )
+          None
+        }
+
+        child("outputFile") match {
+          case Some(out) =>
+            // Explicit output path; resolve relative entries against the module base directory.
+            val f = new File(out)
+            val jar = if (f.isAbsolute) f else new File(p.getBasedir, out)
+            if (jar.exists()) Some(jar) else warnMissing(jar)
+          case None =>
+            // With shadedArtifactAttached the shaded JAR is a secondary (classified) artifact and
+            // the module's main artifact stays unshaded, so target/classes remains correct.
+            val attached = child("shadedArtifactAttached").exists(_.equalsIgnoreCase("true"))
+            if (attached) None
+            else {
+              val base = child("finalName").getOrElse(build.getFinalName)
+              val jar = new File(build.getDirectory, s"$base.jar")
+              if (jar.exists()) Some(jar) else warnMissing(jar)
+            }
+        }
+      }
+    }
+
     val reactorArtifactIds = session.getProjects().asScala.map(_.getArtifactId).toSet
 
     def getBloopName(artifactId: String, configuration: String): String = {
@@ -162,19 +222,39 @@ object MojoImplementation {
     val project = mojo.getProject()
     val dependencies =
       session.getProjectDependencyGraph.getUpstreamProjects(project, true).asScala.toList
+
+    // Reactor deps whose output we replace with a shaded JAR. These must be dropped from the bloop
+    // `dependencies` list as well: a bloop project dependency contributes that project's classesDir
+    // (target/classes) to the effective compile classpath, which would re-introduce the empty
+    // directory we are substituting away on the classpath. The shaded JAR is a self-contained
+    // binary, so the dependent should consume it as a library, not as a project dependency.
+    val shadedDeps: Map[MavenProject, File] =
+      dependencies.flatMap(d => shadedJarOf(d).map(d -> _)).toMap
+    val shadedDepArtifactIds: Set[String] = shadedDeps.keySet.map(_.getArtifactId)
+
     val dependencyNames = dependencies.flatMap(dep => {
       val matchingArtifacts = project.getArtifacts.asScala.filter(a =>
         ArtifactUtils.versionlessKey(dep.getArtifact) == ArtifactUtils.versionlessKey(a)
       )
 
       log.info(s"Dependency $dep, $matchingArtifacts")
-      matchingArtifacts
-        .collect {
-          case artifact if artifact.getType == "test-jar" => getBloopName(dep.getArtifactId, "test")
-        }
-        .toList
-        .appended(dep.getArtifactId)
+      val testNames = matchingArtifacts.collect {
+        case artifact if artifact.getType == "test-jar" => getBloopName(dep.getArtifactId, "test")
+      }.toList
+      // Drop only the main project dependency when its output is replaced by a shaded JAR. A
+      // consumed test-jar is a separate artifact that shade's main-artifact replacement does not
+      // touch, so its dependency name is preserved.
+      if (shadedDepArtifactIds.contains(dep.getArtifactId)) testNames
+      else testNames.appended(dep.getArtifactId)
     })
+
+    // Map each shaded reactor dep's compile output directory (target/classes) to its shaded JAR, so
+    // we can substitute it wherever the stale output directory would otherwise reach a dependent's
+    // classpath. Keyed by canonical path to match the explicit list and Maven-resolved entries.
+    def canon(p: String): String = new File(p).getCanonicalPath
+    val shadedByOutputDir: Map[String, String] =
+      shadedDeps.map { case (d, jar) => canon(d.getBuild.getOutputDirectory) -> jar.getAbsolutePath }
+    def substituteShaded(path: String): String = shadedByOutputDir.getOrElse(canon(path), path)
 
     val configDir = mojo.getBloopConfigDir.toPath()
     if (!Files.exists(configDir)) Files.createDirectory(configDir)
@@ -300,12 +380,16 @@ object MojoImplementation {
           if (!resolvedArtifactKeys.contains(ArtifactUtils.versionlessKey(d.getArtifact))) Nil
           else {
             val build = d.getBuild()
-            if (configuration == "compile") build.getOutputDirectory() :: Nil
-            else build.getTestOutputDirectory() :: build.getOutputDirectory() :: Nil
+            val dirs =
+              if (configuration == "compile") build.getOutputDirectory() :: Nil
+              else build.getTestOutputDirectory() :: build.getOutputDirectory() :: Nil
+            dirs.map(substituteShaded)
           }
         }
 
-        val cp = classpath0().asScala.toList.asInstanceOf[List[String]].map(u => abs(new File(u)))
+        val cp = classpath0().asScala.toList
+          .asInstanceOf[List[String]]
+          .map(u => abs(new File(substituteShaded(u))))
         // scalaLibrary might not be added by default to classpath and it's needed for the compilation
         val hasScalaLibrary = cp.exists(p => p.toFile().getName().contains("scala_library-"))
 

--- a/src/test/resources/shade_relocation/consumer/pom.xml
+++ b/src/test/resources/shade_relocation/consumer/pom.xml
@@ -1,0 +1,27 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>consumer</artifactId>
+  <version>0.1</version>
+  <name>consumer</name>
+  <description>Depends on the shaded `lib` module.</description>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>shade_relocation</artifactId>
+    <version>0.1</version>
+  </parent>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <encoding>UTF-8</encoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>lib</artifactId>
+      <version>0.1</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/test/resources/shade_relocation/consumer/src/main/java/com/example/consumer/App.java
+++ b/src/test/resources/shade_relocation/consumer/src/main/java/com/example/consumer/App.java
@@ -1,0 +1,9 @@
+package com.example.consumer;
+
+import com.example.lib.Greeter;
+
+public class App {
+    public static void main(String[] args) {
+        System.out.println(new Greeter().greet("world"));
+    }
+}

--- a/src/test/resources/shade_relocation/lib/pom.xml
+++ b/src/test/resources/shade_relocation/lib/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>lib</artifactId>
+  <version>0.1</version>
+  <name>lib</name>
+  <description>A module that shades and relocates a third-party dependency.</description>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>shade_relocation</artifactId>
+    <version>0.1</version>
+  </parent>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <encoding>UTF-8</encoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <relocations>
+                <relocation>
+                  <pattern>org.apache.commons.lang3</pattern>
+                  <shadedPattern>com.example.lib.shaded.lang3</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/test/resources/shade_relocation/lib/src/main/java/com/example/lib/Greeter.java
+++ b/src/test/resources/shade_relocation/lib/src/main/java/com/example/lib/Greeter.java
@@ -1,0 +1,11 @@
+package com.example.lib;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class Greeter {
+    public String greet(String name) {
+        // References a class that shade relocates into com.example.lib.shaded.lang3,
+        // so the resulting bytecode only resolves against the shaded JAR.
+        return "Hello, " + StringUtils.capitalize(name);
+    }
+}

--- a/src/test/resources/shade_relocation/pom.xml
+++ b/src/test/resources/shade_relocation/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>shade_relocation</artifactId>
+  <version>0.1</version>
+  <packaging>pom</packaging>
+  <name>shade_relocation</name>
+  <description>Reactor with a maven-shade-plugin module consumed by a dependent.</description>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <encoding>UTF-8</encoding>
+  </properties>
+
+  <modules>
+    <module>lib</module>
+    <module>consumer</module>
+  </modules>
+
+</project>

--- a/src/test/scala/bloop/integrations/maven/MavenConfigGenerationTest.scala
+++ b/src/test/scala/bloop/integrations/maven/MavenConfigGenerationTest.scala
@@ -182,6 +182,68 @@ class MavenConfigGenerationTest extends BaseConfigSuite {
   }
 
   @Test
+  def shadeRelocation() = {
+    // `lib` is built by maven-shade-plugin: its relocated classes live only inside lib-0.1.jar,
+    // never in lib/target/classes. The dependent `consumer` must therefore see the shaded JAR on
+    // its classpath, not the (empty) output directory. Package first so the shaded JAR exists.
+    check(
+      "shade_relocation/pom.xml",
+      submodules = List("shade_relocation/lib/pom.xml", "shade_relocation/consumer/pom.xml"),
+      prePackage = true
+    ) {
+      case (configFile, projectName, List(lib, consumer)) =>
+        assert(
+          hasCompileClasspathEntryName(consumer, "lib-0.1.jar"),
+          s"consumer should depend on the shaded JAR lib-0.1.jar; classpath=${consumer.project.classpath}"
+        )
+        val staleOutputDir = "lib" + File.separator + "target" + File.separator + "classes"
+        assert(
+          !hasCompileClasspathEntryName(consumer, staleOutputDir),
+          s"consumer must NOT link the stale $staleOutputDir; classpath=${consumer.project.classpath}"
+        )
+        // The shaded module must NOT remain a bloop project dependency: a project dependency
+        // contributes its classesDir (lib/target/classes) to the effective classpath, which would
+        // re-introduce the empty directory through the dependency graph.
+        assert(
+          !consumer.project.dependencies.contains("lib"),
+          s"consumer must not keep `lib` as a project dependency; deps=${consumer.project.dependencies}"
+        )
+      case _ =>
+        assert(false, "shade_relocation should have lib and consumer submodules")
+    }
+  }
+
+  @Test
+  def shadeRelocationCleanFallback() = {
+    // Without a prior `package`, the shaded JAR does not exist yet (shade binds to package, after
+    // bloopInstall's generate-resources). This locks in the documented warn+fallback behavior:
+    // the plugin must NOT wire a (stale) JAR, and instead leaves `lib` as a normal project
+    // dependency with its target/classes on the classpath, exactly as before the shade handling.
+    check(
+      "shade_relocation/pom.xml",
+      submodules = List("shade_relocation/lib/pom.xml", "shade_relocation/consumer/pom.xml"),
+      prePackage = false
+    ) {
+      case (configFile, projectName, List(lib, consumer)) =>
+        val staleOutputDir = "lib" + File.separator + "target" + File.separator + "classes"
+        assert(
+          hasCompileClasspathEntryName(consumer, staleOutputDir),
+          s"clean export should fall back to $staleOutputDir; classpath=${consumer.project.classpath}"
+        )
+        assert(
+          !hasCompileClasspathEntryName(consumer, "lib-0.1.jar"),
+          s"clean export must NOT wire a shaded JAR that was not built; classpath=${consumer.project.classpath}"
+        )
+        assert(
+          consumer.project.dependencies.contains("lib"),
+          s"clean export should keep `lib` as a project dependency; deps=${consumer.project.dependencies}"
+        )
+      case _ =>
+        assert(false, "shade_relocation should have lib and consumer submodules")
+    }
+  }
+
+  @Test
   def noLibrary() = {
     check("no_library/pom.xml") { (configFile, projectName, subprojects) =>
       assert(subprojects.isEmpty)
@@ -358,7 +420,8 @@ class MavenConfigGenerationTest extends BaseConfigSuite {
   private def check(
       testProject: String,
       submodules: List[String] = Nil,
-      extraContent: Map[String, String] = Map.empty
+      extraContent: Map[String, String] = Map.empty,
+      prePackage: Boolean = false
   )(
       checking: (Config.File, String, List[Config.File]) => Unit
   ): Unit = {
@@ -394,6 +457,16 @@ class MavenConfigGenerationTest extends BaseConfigSuite {
     properties.load(bloopProperties)
     val version = properties.get("version").asInstanceOf[String]
 
+    // maven-shade-plugin binds to the `package` phase, while bloopInstall runs at generate-sources.
+    // For fixtures that rely on a shaded JAR existing on disk, package the reactor first.
+    val packageResult =
+      if (prePackage)
+        exec(
+          List(javaArgs, jarArgs, List("package", "-DskipTests")).flatten,
+          outFile.getParent().toFile()
+        )
+      else Try("")
+
     val command =
       List(s"ch.epfl.scala:bloop-maven-plugin:$version:bloopInstall", "-DdownloadSources=true")
     val allArgs = List(
@@ -421,6 +494,7 @@ class MavenConfigGenerationTest extends BaseConfigSuite {
       ()
     } catch {
       case NonFatal(e) =>
+        if (prePackage) println("Maven package output:\n" + packageResult)
         println("Maven output:\n" + result)
         throw e
     }


### PR DESCRIPTION
# Link dependents of shaded reactor modules to the shaded JAR instead of `target/classes`

## Problem

A reactor module built by `maven-shade-plugin` (uber-jar / class relocation) keeps relocated classes only inside the shaded JAR, never in `target/classes`. But the plugin linked that module's dependents to `target/classes`, so they got an empty directory on their classpath and failed with `cannot find symbol`, cascading down the subtree (e.g. neo4j: `lucene9-shaded` → `lucene-index` → the cypher Scala stack, ~16 modules).

Fixes [scalameta/metals#3024](https://github.com/scalameta/metals/issues/3024).

## Root cause

The stale `target/classes` reached dependents through two paths: the explicit reactor-dependency list (`build.getOutputDirectory()`) and Maven's resolved classpath elements. A third, subtler leak: a shaded module left as a Bloop **project dependency** contributes its `classesDir` to the effective classpath through the dependency graph.

## Fix (plugin-only; Bloop core / Metals just consume the emitted JSON)

- **Detect** shaded reactor deps via an execution that binds the `shade` goal (not mere plugin presence), and **locate** the JAR honoring `outputFile` / `finalName` / `shadedArtifactAttached`. The module's GAV is never resolved from a repository (could wire a stale binary).
- **Substitute** the shaded JAR for `target/classes` at both classpath entry points.
- **Drop** the shaded module's main project dependency so its `classesDir` can't leak back via the dependency graph; a consumed `test-jar` name is preserved (shade replaces the main artifact, not the test-jar).

## Behavior when the shaded JAR doesn't exist yet

`bloopInstall` runs at `generate-resources`, while shade binds to `package`. On a clean tree the shaded JAR legitimately may not exist yet. In that case the plugin **warns loudly** (naming the module, telling the user to `mvn package`) and falls back to the previous `target/classes` behavior, rather than failing the export or wiring an unrelated binary.

This keeps the plugin consistent with its existing architecture (cf. "Download only external dependencies in multi module Maven projects" — the plugin deliberately avoids invoking Maven tasks and resolving reactor artifacts to stay fast at an early lifecycle phase). Making the **default** export fully self-sufficient for shaded modules (triggering the shade goal during export) is a larger change best handled on the Metals/import side, and is intentionally out of scope here.

## Known gaps (not blocking)

- The `outputFile` / `shadedArtifactAttached` / shade-`finalName` branches and the shaded-module-with-consumed-test-jar path are correct by construction but not yet covered by dedicated fixtures (each needs its own packaged module).
