### PR TITLE
Document --add-exports limitation and test javac arg forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,36 @@ This repository holds the Maven Plugin for
 - To get started please refer to the docs [here](https://scalacenter.github.io/bloop/docs/build-tools/maven).
 - If you're looking for the main Bloop codebase, head over [here](https://github.com/scalacenter/bloop).
 - If you're interested in contributing, check out our [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## Known limitations
+
+### `--add-exports` / `--add-opens` and JDK-internal types
+
+If a Java class extends or otherwise hard-depends on a JDK-internal type that is
+only reachable via `--add-exports`/`--add-opens` (for example a class extending
+`jdk.javadoc.internal.tool.DocEnvImpl`), Bloop can fail to compile it even though
+Maven succeeds, with an error such as:
+
+```
+java.lang.IllegalAccessError: superclass access check failed: ... cannot access
+class jdk.javadoc.internal.tool.DocEnvImpl (in module jdk.javadoc) because module
+jdk.javadoc does not export jdk.javadoc.internal.tool to unnamed module
+```
+
+This plugin **does** forward those options correctly: any `--add-exports` you set
+in `maven-compiler-plugin`'s `<compilerArgs>` ends up verbatim in the generated
+`java.options`, so `javac` itself compiles fine. The failure happens *afterwards*,
+when Zinc (inside the Bloop **server** JVM) reflectively loads the freshly compiled
+classes to extract their API — that JVM was not launched with the `--add-exports`
+flag, so the class load is rejected. This is outside the reach of a per-project
+config file and is tracked upstream in
+[sbt/zinc#837](https://github.com/sbt/zinc/issues/837).
+
+**Workaround:** start the Bloop server with the same flag, e.g.
+
+```bash
+export BLOOP_JAVA_OPTS="--add-exports jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED"
+```
+
+(or set the equivalent `bloop.java-opts` property). This grants the export to the
+JVM that runs Zinc. Note it is global to the server, not per-project.

--- a/src/test/resources/issue_26/pom.xml
+++ b/src/test/resources/issue_26/pom.xml
@@ -1,0 +1,34 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>bloop.test</groupId>
+  <artifactId>issue_26</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>issue-26-test</name>
+  <description>Java-only module passing a JPMS --add-exports javac option (see issue #26).</description>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <compilerArgs>
+            <arg>--add-exports</arg>
+            <arg>jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/scala/bloop/integrations/maven/MavenConfigGenerationTest.scala
+++ b/src/test/scala/bloop/integrations/maven/MavenConfigGenerationTest.scala
@@ -202,6 +202,28 @@ class MavenConfigGenerationTest extends BaseConfigSuite {
     }
   }
 
+  // See https://github.com/scalacenter/bloop-maven-plugin/issues/26 and the upstream
+  // sbt/zinc#837. The plugin's only responsibility for `--add-exports` is to forward it
+  // verbatim from maven-compiler-plugin's <compilerArgs> into the bloop config's
+  // `java.options`; the IllegalAccessError reported in #26 happens later, inside zinc's
+  // API extraction in the bloop server JVM, which is outside this plugin's reach.
+  @Test
+  def issue26() = {
+    check("issue_26/pom.xml") { (configFile, _, subprojects) =>
+      assert(subprojects.isEmpty)
+      assert(configFile.project.`scala`.isEmpty, "issue_26 is a Java-only module")
+      val opts = configFile.project.java.get.options
+      assert(
+        opts.contains("--add-exports"),
+        s"java.options should forward --add-exports, was: $opts"
+      )
+      assert(
+        opts.contains("jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED"),
+        s"java.options should forward the --add-exports value, was: $opts"
+      )
+    }
+  }
+
   @Test
   def conflictingSubmodules() = {
     check(


### PR DESCRIPTION
`javac` compiles fine — the `IllegalAccessError` in #26 is thrown afterwards, in zinc's API extraction (`ClassToAPI`), which reflectively loads the compiled class in the **Bloop server JVM**. That JVM isn't started with `--add-exports`, so the JPMS access check rejects the load: the flag reaches `javac` but not the JVM running zinc.

Not fixable in this plugin — it only generates config, and already forwards `--add-exports` into `java.options`. Tracked upstream in **sbt/zinc#837**.

**Workaround:** start the server with `BLOOP_JAVA_OPTS="--add-exports jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED"` (global to the server, not per-project).

Refs #26.
