### PR TITLE
Support per-execution scalac configuration (#29)

### DIFF
--- a/src/main/java/bloop/integrations/maven/BloopMojo.java
+++ b/src/main/java/bloop/integrations/maven/BloopMojo.java
@@ -84,6 +84,8 @@ public class BloopMojo extends ExtendedScalaContinuousCompileMojo {
 
     private ModuleType moduleType;
     private List<String> javaCompilerArgs;
+    private List<String> compileScalacArgs;
+    private List<String> testScalacArgs;
 
     @Parameter(property = "launchers")
     private AppLauncher[] launchers;
@@ -183,6 +185,24 @@ public class BloopMojo extends ExtendedScalaContinuousCompileMojo {
     public void setJavaCompilerArgs( List<String> javaCompilerArgs )
     {
         this.javaCompilerArgs = javaCompilerArgs;
+    }
+
+    public void setCompileScalacArgs( List<String> compileScalacArgs )
+    {
+        this.compileScalacArgs = compileScalacArgs;
+    }
+
+    public void setTestScalacArgs( List<String> testScalacArgs )
+    {
+        this.testScalacArgs = testScalacArgs;
+    }
+
+    public List<String> getCompileScalacArgs() {
+        return compileScalacArgs;
+    }
+
+    public List<String> getTestScalacArgs() {
+        return testScalacArgs;
     }
 
     public static enum ModuleType {

--- a/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -13,6 +13,7 @@ import bloop.config.Tag
 import org.apache.maven.artifact.Artifact
 import org.apache.maven.artifact.ArtifactUtils
 import org.apache.maven.execution.MavenSession
+import org.apache.maven.model.PluginExecution
 import org.apache.maven.model.Resource
 import org.apache.maven.plugin.MavenPluginManager
 import org.apache.maven.plugin.Mojo
@@ -39,16 +40,47 @@ object MojoImplementation {
   ): Either[String, BloopMojo] = {
     val buildPlugins = project.getBuild().getPluginsAsMap();
 
-    val (newConfig, moduleType) = Option(buildPlugins.get(ScalaMavenGroupArtifact)) match {
-      case None => (None, BloopMojo.ModuleType.JAVA)
-      case Some(scalaMavenPlugin) =>
-        val pluginConfig = Option(scalaMavenPlugin.getConfiguration).map(_.asInstanceOf[Xpp3Dom])
-        val executionConfigs = scalaMavenPlugin.getExecutions.asScala
-          .flatMap(e => Option(e.getConfiguration).map(_.asInstanceOf[Xpp3Dom]))
-        val combinedConfig = (executionConfigs ++ pluginConfig)
-          .reduceOption((dominant, recessive) => Xpp3Dom.mergeXpp3Dom(dominant, recessive))
-        (combinedConfig, BloopMojo.ModuleType.SCALA)
-    }
+    // Xpp3Dom.mergeXpp3Dom mutates its dominant argument in place. Every DOM we feed into a
+    // merge must therefore be a private deep copy of the Maven model object: without cloning,
+    // building one view (e.g. the union) would pollute the execution DOMs that are reused to
+    // build the other views (e.g. the compile split), leaking one goal's config into another.
+    def cloneDom(dom: Xpp3Dom): Xpp3Dom = new Xpp3Dom(dom)
+    def reduceConfigs(configs: Seq[Xpp3Dom]): Option[Xpp3Dom] =
+      configs
+        .map(cloneDom)
+        .reduceOption((dominant, recessive) => Xpp3Dom.mergeXpp3Dom(dominant, recessive))
+
+    // Derive each goal's scalac options from the config Maven would pass to scala:compile /
+    // scala:testCompile: the plugin-level <configuration> merged with the <configuration> of the
+    // executions bound to that goal (execution-level dominates). Scope note: only scalac options
+    // are split per goal. Everything else (scala version/context, compiler jars, organization,
+    // source filters, compile setup) is still taken from the union view / primary mojo below and
+    // therefore cannot currently differ between the compile and test projects.
+    val (newConfig, compileConfig, testConfig, moduleType) =
+      Option(buildPlugins.get(ScalaMavenGroupArtifact)) match {
+        case None => (None, None, None, BloopMojo.ModuleType.JAVA)
+        case Some(scalaMavenPlugin) =>
+          val pluginConfig = Option(scalaMavenPlugin.getConfiguration).map(_.asInstanceOf[Xpp3Dom])
+          val executions = scalaMavenPlugin.getExecutions.asScala.toSeq
+          def configOf(e: PluginExecution): Option[Xpp3Dom] =
+            Option(e.getConfiguration).map(_.asInstanceOf[Xpp3Dom])
+          def goalsOf(e: PluginExecution): List[String] =
+            Option(e.getGoals).map(_.asScala.toList).getOrElse(Nil)
+          // An execution with no goals binds to nothing in Maven, so its config is deliberately
+          // excluded from both goal-scoped splits. It still feeds the union/primary mojo, which
+          // backs scala-version detection regardless of where <scalaVersion> is declared.
+          def boundTo(goal: String)(e: PluginExecution): Boolean = goalsOf(e).contains(goal)
+
+          // Each call re-clones from the originals (see cloneDom above), so the union, compile
+          // and test views are fully isolated from each other and from the Maven model.
+          def mergedConfig(selected: Seq[PluginExecution]): Option[Xpp3Dom] =
+            reduceConfigs(selected.flatMap(configOf) ++ pluginConfig)
+
+          val combinedConfig = mergedConfig(executions)
+          val compileSplit = mergedConfig(executions.filter(boundTo("compile")))
+          val testSplit = mergedConfig(executions.filter(boundTo("testCompile")))
+          (combinedConfig, compileSplit, testSplit, BloopMojo.ModuleType.SCALA)
+      }
 
     val javaCompilerArgs: List[String] = Option(buildPlugins.get(JavaMavenGroupArtifact)) match {
       case None => List()
@@ -60,15 +92,60 @@ object MojoImplementation {
         } else List()
     }
 
+    // Capture the current execution configuration BEFORE any mutation below, since each
+    // getConfiguredMojo call requires us to (re)set mojoExecution's configuration in place.
     val currentConfig = mojoExecution.getConfiguration
     val dom = newConfig.map(nc => Xpp3Dom.mergeXpp3Dom(nc, currentConfig))
     Try {
+      // Extract the scalac args produced by a given split. We go through a configured mojo
+      // (rather than reading <args> from the DOM) so that compiler-plugin options and
+      // target/release flags are appended exactly as scala-maven-plugin would. An absent split
+      // is not "no options": it means the goal has no per-execution override, so we fall back to
+      // the effective default config (currentConfig) and let scala-maven-plugin synthesize its
+      // defaults (e.g. -target/-release from maven.compiler.*) and honor user properties.
+      def scalacArgsFor(split: Option[Xpp3Dom]): java.util.List[String] = {
+        val effectiveConfig = split match {
+          case Some(config) => Xpp3Dom.mergeXpp3Dom(config, currentConfig)
+          case None => currentConfig
+        }
+        mojoExecution.setConfiguration(effectiveConfig)
+        val configuredMojo = mavenPluginManager
+          .getConfiguredMojo(classOf[Mojo], session, mojoExecution)
+          .asInstanceOf[BloopMojo]
+        // getScalacArgs resolves the Scala version/context, which can legitimately fail for a
+        // Java-only module that merely inherits scala-maven-plugin. As before, swallow that and
+        // fall back to no scalac options rather than aborting the whole module's config. Log at
+        // debug so a genuine failure (e.g. compiler-plugin resolution) is still discoverable.
+        Try(configuredMojo.getScalacArgs) match {
+          case Success(args) => args
+          case Failure(e) =>
+            configuredMojo.getLog.debug(
+              s"Could not resolve scalac options for ${project.getArtifactId()}; " +
+                "falling back to none",
+              e
+            )
+            java.util.Collections.emptyList[String]()
+        }
+      }
+
+      // Java-only modules have no Scala compilation (scalaContext is None), so their scalac args
+      // are never read; skip configuring a mojo for them.
+      val isScalaModule = moduleType == BloopMojo.ModuleType.SCALA
+      val compileScalacArgs: java.util.List[String] =
+        if (isScalaModule) scalacArgsFor(compileConfig) else java.util.Collections.emptyList()
+      val testScalacArgs: java.util.List[String] =
+        if (isScalaModule) scalacArgsFor(testConfig) else java.util.Collections.emptyList()
+
+      // Build the primary mojo LAST so mojoExecution ends in the union configuration. The
+      // union backs scala-version detection (see commit 5a1c6c3), source dirs, java args, etc.
       dom.foreach(mojoExecution.setConfiguration)
       val mojo = mavenPluginManager
         .getConfiguredMojo(classOf[Mojo], session, mojoExecution)
         .asInstanceOf[BloopMojo]
       mojo.setModuleType(moduleType)
       mojo.setJavaCompilerArgs(javaCompilerArgs.asJava)
+      mojo.setCompileScalacArgs(compileScalacArgs)
+      mojo.setTestScalacArgs(testScalacArgs)
       mojo
     } match {
       case Success(value) => Right(value)
@@ -206,8 +283,6 @@ object MojoImplementation {
           artifact.getGroupId()
       }
       .getOrElse("org.scala-lang")
-    val scalacArgs =
-      Try(mojo.getScalacArgs()).toOption.toList.map(_.asScala.toList).flatten.filter(_ != null)
 
     def writeConfig(
         sourceDirs0: Seq[File],
@@ -220,6 +295,11 @@ object MojoImplementation {
         configuration: String
     ): Unit = {
       val name = getBloopName(project.getArtifactId(), configuration)
+      // Per-execution scalac options: the `compile` goal and `testCompile` goal can differ.
+      val scalacArgsRaw =
+        if (configuration == "test") mojo.getTestScalacArgs else mojo.getCompileScalacArgs
+      val scalacArgs =
+        Option(scalacArgsRaw).toList.flatMap(_.asScala.toList).filter(_ != null)
       val build = project.getBuild()
       val baseDirectory = abs(project.getBasedir())
       val out = baseDirectory.resolve("target")

--- a/src/test/resources/issue_29/pom.xml
+++ b/src/test/resources/issue_29/pom.xml
@@ -1,0 +1,100 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>issue_29</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>issue_29</name>
+  <description>Different scalac options for the compile and testCompile goals (issue #29).</description>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <encoding>UTF-8</encoding>
+    <scala.version>2.13.6</scala.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>2.13.9</version>
+    </dependency>
+
+    <!-- Test -->
+    <dependency>
+      <groupId>org.scalameta</groupId>
+      <artifactId>munit_2.13</artifactId>
+      <version>0.7.26</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src/main/scala</sourceDirectory>
+    <testSourceDirectory>src/test/scala</testSourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>4.9.1</version>
+        <!--
+          Plugin-level config. scalaVersion is inherited by both goals; the <args> here is
+          overridden (replaced) by each execution's own <args>, per Maven's merge semantics.
+        -->
+        <configuration>
+          <scalaVersion>2.13.6</scalaVersion>
+          <args>
+            <arg>-deprecation</arg>
+          </args>
+        </configuration>
+        <executions>
+          <!--
+            Per-execution overrides. In the original report kind-projector was enabled here;
+            we use plain scalac flags so the test does not need to resolve a compiler-plugin jar.
+          -->
+          <execution>
+            <id>scala-compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <args>
+                <arg>-Ywarn-unused</arg>
+              </args>
+            </configuration>
+          </execution>
+          <execution>
+            <id>scala-test-compile</id>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <args>
+                <arg>-Xfatal-warnings</arg>
+              </args>
+              <!--
+                A config child the compile execution lacks. It must NOT leak into the compile
+                Bloop options: if the split DOMs were merged without cloning, building the union
+                view would graft this onto the (shared) compile execution DOM.
+              -->
+              <addScalacArgs>-Xtest-only</addScalacArgs>
+            </configuration>
+          </execution>
+          <!--
+            An execution bound to an unrelated goal. Its config must NOT contribute scalac options
+            to either the compile or the test Bloop project, since neither binds to add-source.
+          -->
+          <execution>
+            <id>scala-add-source</id>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <addScalacArgs>-Xunrelated-goal</addScalacArgs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/scala/bloop/integrations/maven/MavenConfigGenerationTest.scala
+++ b/src/test/scala/bloop/integrations/maven/MavenConfigGenerationTest.scala
@@ -298,6 +298,15 @@ class MavenConfigGenerationTest extends BaseConfigSuite {
         assertEquals(List("multi_module_test_jar"), module1.project.dependencies)
         assertEquals(List("multi_module_test_jar", "foo-test", "foo"), module2.project.dependencies)
 
+        // The submodules declare scala-maven-plugin executions but no <configuration> (it comes
+        // from inherited pluginManagement). "No per-goal override" must still mean "Maven's
+        // effective config", so scala-maven-plugin's synthesized default for
+        // maven.compiler.target=1.8 (-target:8) must survive rather than collapse to no options.
+        List(module1, module2).foreach { module =>
+          val opts = module.project.`scala`.get.options
+          assert(opts.contains("-target:8"), s"scalac opts: $opts")
+        }
+
       case _ =>
         assert(false, "Multi module test jar should have two submodules")
     }
@@ -352,6 +361,39 @@ class MavenConfigGenerationTest extends BaseConfigSuite {
         "junit-interface should be present in test classpath when junit is used",
         hasJunitInterfaceInClasspath
       )
+    }
+  }
+
+  @Test
+  def issue29() = {
+    // The compile and testCompile goals carry different scalac options via per-execution
+    // configuration; each bloop project should only see its own (plus shared plugin-level) args.
+    check("issue_29/pom.xml") { (configFile, projectName, subprojects) =>
+      assert(subprojects.isEmpty)
+      val compileOpts = configFile.project.`scala`.get.options
+      val testOpts = readValidBloopConfig(
+        configFile.project.directory.resolve(".bloop").resolve(s"$projectName-test.json").toFile()
+      ).project.`scala`.get.options
+
+      assert(compileOpts.contains("-Ywarn-unused"), s"compile opts: $compileOpts")
+      assert(!compileOpts.contains("-Xfatal-warnings"), s"compile opts: $compileOpts")
+      assert(testOpts.contains("-Xfatal-warnings"), s"test opts: $testOpts")
+      assert(!testOpts.contains("-Ywarn-unused"), s"test opts: $testOpts")
+
+      // A per-execution <args> overrides (replaces) the plugin-level <args>, mirroring Maven's
+      // own configuration-merge semantics, so the shared -deprecation does not leak into either.
+      assert(!compileOpts.contains("-deprecation"), s"compile opts: $compileOpts")
+      assert(!testOpts.contains("-deprecation"), s"test opts: $testOpts")
+
+      // The testCompile-only addScalacArgs must stay out of the compile options: the split
+      // config DOMs must not contaminate each other when the union view is built.
+      assert(testOpts.contains("-Xtest-only"), s"test opts: $testOpts")
+      assert(!compileOpts.contains("-Xtest-only"), s"compile opts: $compileOpts")
+
+      // An execution bound to an unrelated goal (add-source) must not contribute scalac options
+      // to either project; only compile/testCompile-bound executions feed the goal-scoped splits.
+      assert(!compileOpts.contains("-Xunrelated-goal"), s"compile opts: $compileOpts")
+      assert(!testOpts.contains("-Xunrelated-goal"), s"test opts: $testOpts")
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #29.

Maven lets the `scala-maven-plugin` `<configuration>` be overridden on a [per-execution basis](https://maven.apache.org/guides/mini/guide-configuring-plugins.html#using-the-executions-tag), so the `compile` and `testCompile` goals can carry **different** scalac options — e.g. enabling `kind-projector` for one but not the other.

Previously the plugin merged *all* executions into a single union config and applied it to both the compile and test Bloop projects, so per-goal differences were lost: Maven would compile the project fine while Bloop/Metals diverged.

## What changed

`initializeMojo` now derives each goal's scalac options from the config Maven itself would pass to `scala:compile` / `scala:testCompile`: the plugin-level `<configuration>` merged with the `<configuration>` of the executions bound to that goal (execution-level dominating). The resulting compile/test arg lists are stashed on `BloopMojo` and selected per configuration when writing each Bloop project.

Notable details:

- **DOM cloning** — `Xpp3Dom.mergeXpp3Dom` mutates its dominant argument, so every DOM is deep-cloned before merging. Without this, building one view (the union) would contaminate the shared Maven-model objects reused to build the compile/test splits.
- **Exact goal matching** — only executions bound to `compile` / `testCompile` feed the respective split. Executions bound to unrelated goals (e.g. `add-source`) or no goals are excluded from the splits, but still feed the union/primary mojo, which backs Scala-version detection.
- **Effective-config fallback** — a goal with no per-execution override falls back to the effective default config, so `scala-maven-plugin` still synthesizes its defaults (`-target`/`-release` from `maven.compiler.*`) and honors user properties, rather than collapsing to no options.
- **Resilience** — `getScalacArgs` failures are swallowed (logged at debug) so a Java-only module that merely inherits `scala-maven-plugin` still gets a config written, matching the previous forgiving behavior.

**Scope:** only scalac options are split per goal. Scala version/context, compiler jars, organization and compile setup still come from the union view, as these don't vary per goal in practice.
