### PR TITLE
Use systemPath for system-scoped dependencies instead of remote resolution (#27)

### DIFF
--- a/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
+++ b/src/main/scala/bloop/integrations/maven/MojoImplementation.scala
@@ -250,15 +250,31 @@ object MojoImplementation {
                     art.setVersion(context.version.toString)
                 case _ =>
               }
-            resolveArtifact(art).foreach { resolvedFile =>
-              // since we don't resolve dependencies automatically in the plugin, this will be null
-              art.setFile(resolvedFile)
+            if (art.getScope() == Artifact.SCOPE_SYSTEM) {
+              // System-scoped deps are not in any repository; their jar is the
+              // <systemPath> file Maven already set. Never resolve remotely
+              // (issue #27 — transitive system deps like jdk.tools:jdk.tools).
+              val file = art.getFile()
+              if (file != null && file.exists())
+                Some(artifactToConfigModule(art, project, session))
+              else {
+                log.warn(
+                  s"Skipping system-scoped artifact $art: systemPath file missing " +
+                    s"(${Option(file).map(_.getPath).getOrElse("null")})"
+                )
+                None
+              }
+            } else {
+              resolveArtifact(art).foreach { resolvedFile =>
+                // since we don't resolve dependencies automatically in the plugin, this will be null
+                art.setFile(resolvedFile)
+              }
+              if (mojo.shouldDownloadSources()) {
+                resolveArtifact(art, sources = true)
+              }
+              Some(artifactToConfigModule(art, project, session))
             }
-            if (mojo.shouldDownloadSources()) {
-              resolveArtifact(art, sources = true)
-            }
-            artifactToConfigModule(art, project, session)
-        }
+        }.flatten
 
       val (modules, extraClasspath) = {
         val hasJunit =

--- a/src/test/resources/issue_27/pom.xml
+++ b/src/test/resources/issue_27/pom.xml
@@ -1,0 +1,57 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>issue_27</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <name>issue_27</name>
+  <description>A Scala project with a system-scoped dependency (issue #27): the plugin must use the provided systemPath and must NOT try to resolve it remotely.</description>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <encoding>UTF-8</encoding>
+    <scala.version>2.13.6</scala.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+
+    <!-- System-scoped dependency pointing at a jar guaranteed present in any JDK 9+.
+         The plugin must use this path and not attempt remote resolution. -->
+    <dependency>
+      <groupId>com.example.system</groupId>
+      <artifactId>fake-system-lib</artifactId>
+      <version>1.0</version>
+      <scope>system</scope>
+      <systemPath>${java.home}/lib/jrt-fs.jar</systemPath>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src/main/scala</sourceDirectory>
+    <testSourceDirectory>src/test/scala</testSourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>3.3.2</version>
+        <configuration></configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <args></args>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/issue_27_multimodule/app/pom.xml
+++ b/src/test/resources/issue_27_multimodule/app/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>app</artifactId>
+  <version>0.1</version>
+  <name>app</name>
+  <description>Application module that depends on 'lib'. It does NOT inherit lib's system-scoped dependency, since Maven does not make system scope transitive; this module checks the multi-module reactor builds cleanly.</description>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>issue_27_multimodule</artifactId>
+    <version>0.1</version>
+  </parent>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <encoding>UTF-8</encoding>
+    <scala.version>2.13.6</scala.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>lib</artifactId>
+      <version>0.1</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src/main/scala</sourceDirectory>
+    <testSourceDirectory>src/test/scala</testSourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>3.3.2</version>
+        <configuration></configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <args></args>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/issue_27_multimodule/lib/pom.xml
+++ b/src/test/resources/issue_27_multimodule/lib/pom.xml
@@ -1,0 +1,63 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>lib</artifactId>
+  <version>0.1</version>
+  <name>lib</name>
+  <description>Library module that declares a system-scoped dependency.</description>
+  <parent>
+    <groupId>com.example</groupId>
+    <artifactId>issue_27_multimodule</artifactId>
+    <version>0.1</version>
+  </parent>
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <encoding>UTF-8</encoding>
+    <scala.version>2.13.6</scala.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+
+    <!-- System-scoped dependency pointing at a jar guaranteed present in any JDK 9+.
+         The plugin must use this systemPath instead of resolving it from a remote repo
+         (issue #27). Maven does not make system scope transitive, so this dependency stays
+         local to 'lib' and does not propagate to modules that depend on 'lib'. -->
+    <dependency>
+      <groupId>com.example.system</groupId>
+      <artifactId>fake-system-lib</artifactId>
+      <version>1.0</version>
+      <scope>system</scope>
+      <systemPath>${java.home}/lib/jrt-fs.jar</systemPath>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <sourceDirectory>src/main/scala</sourceDirectory>
+    <testSourceDirectory>src/test/scala</testSourceDirectory>
+    <plugins>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>3.3.2</version>
+        <configuration></configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <args></args>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/issue_27_multimodule/pom.xml
+++ b/src/test/resources/issue_27_multimodule/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>issue_27_multimodule</artifactId>
+  <version>0.1</version>
+  <packaging>pom</packaging>
+  <name>issue_27_multimodule</name>
+  <description>Multi-module reactor where module 'lib' declares a system-scoped dependency and 'app' depends on 'lib'. Verifies bloopInstall handles system scope without remote resolution (issue #27). Maven does not make system scope transitive, so the dependency stays local to 'lib'.</description>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <encoding>UTF-8</encoding>
+  </properties>
+
+  <modules>
+    <module>lib</module>
+    <module>app</module>
+  </modules>
+
+</project>

--- a/src/test/scala/bloop/integrations/maven/MavenConfigGenerationTest.scala
+++ b/src/test/scala/bloop/integrations/maven/MavenConfigGenerationTest.scala
@@ -361,6 +361,20 @@ class MavenConfigGenerationTest extends BaseConfigSuite {
       extraContent: Map[String, String] = Map.empty
   )(
       checking: (Config.File, String, List[Config.File]) => Unit
+  ): Unit =
+    checkWithOutput(testProject, submodules, extraContent) {
+      (configFile, projectName, subProjects, _) => checking(configFile, projectName, subProjects)
+    }
+
+  // Same as `check`, but also hands the raw Maven output (stdout+stderr) to the assertion so
+  // tests can verify behavior that lives in the log, e.g. that the plugin did NOT attempt a
+  // remote download for a system-scoped dependency (issue #27).
+  private def checkWithOutput(
+      testProject: String,
+      submodules: List[String] = Nil,
+      extraContent: Map[String, String] = Map.empty
+  )(
+      checking: (Config.File, String, List[Config.File], String) => Unit
   ): Unit = {
     println(s"Checking $testProject")
     val tempDir = Files.createTempDirectory("mavenBloop")
@@ -403,6 +417,7 @@ class MavenConfigGenerationTest extends BaseConfigSuite {
     ).flatten
 
     val result = exec(allArgs, outFile.getParent().toFile())
+    val mavenOutput = result.getOrElse("")
     try {
       val projectPath = outFile.getParent()
       val projectName = projectPath.toFile().getName()
@@ -416,12 +431,12 @@ class MavenConfigGenerationTest extends BaseConfigSuite {
         val subProjectFile = bloopDir.resolve(s"${subProjectName}.json")
         readValidBloopConfig(subProjectFile.toFile())
       }
-      checking(configFile, projectName, subProjects)
+      checking(configFile, projectName, subProjects, mavenOutput)
       tempDir.toFile().delete()
       ()
     } catch {
       case NonFatal(e) =>
-        println("Maven output:\n" + result)
+        println("Maven output:\n" + mavenOutput)
         throw e
     }
   }
@@ -444,6 +459,9 @@ class MavenConfigGenerationTest extends BaseConfigSuite {
       val out = new StringBuilder()
       processBuilder.directory(cwd)
       processBuilder.command(cmd: _*)
+      // Merge stderr into stdout so assertions can see all Maven/plugin log output
+      // (e.g. "[ERROR] FAILURE ...:system" lines emitted on a failed resolution).
+      processBuilder.redirectErrorStream(true)
       var process = processBuilder.start()
 
       val reader =
@@ -606,6 +624,97 @@ class MavenConfigGenerationTest extends BaseConfigSuite {
         hasRuntimeClasspathEntryName(configFile, "scala-library"),
         "scala-library should still be on the JVM platform runtime classpath"
       )
+    }
+  }
+
+  @Test
+  def issue27() = {
+    // A system-scoped dependency must use its provided <systemPath> instead of being
+    // resolved from remote repositories (issue #27). Without the fix the plugin attempts a
+    // (doomed) remote download and logs "FAILURE ...:system / Could not resolve". We point
+    // systemPath at jrt-fs.jar, which exists in any JDK 9+, so this is reliable cross-JDK.
+    checkWithOutput("issue_27/pom.xml") { (configFile, projectName, subprojects, mavenOutput) =>
+      assert(subprojects.isEmpty)
+      assert(configFile.project.`scala`.isDefined)
+
+      // Core regression contract: the plugin must NOT attempt to remotely resolve/download
+      // the system-scoped artifact. Before the fix the log contains lines such as
+      // "[ERROR] FAILURE ...fake-system-lib...:system" and "Downloading ...fake-system-lib...".
+      assertNoRemoteResolution(mavenOutput, "fake-system-lib")
+
+      // The system-scoped jar must appear on the compile classpath via its systemPath.
+      assert(
+        hasCompileClasspathEntryName(configFile, "jrt-fs.jar"),
+        "system-scoped jar (jrt-fs.jar) should be on the compile classpath"
+      )
+
+      // It must surface as a resolution module pointing at the provided systemPath jar
+      // (jrt-fs.jar) — proving the plugin used the local path, not a remote download.
+      val modules = configFile.project.resolution.toList.flatMap(_.modules)
+      val systemModule = modules.find(_.name == "fake-system-lib")
+      assert(
+        systemModule.isDefined,
+        "system-scoped dependency should be present as a resolution module"
+      )
+      assert(
+        systemModule.get.artifacts.exists(_.path.toString.endsWith("jrt-fs.jar")),
+        "system-scoped module must point at the provided systemPath jar, not a remote download"
+      )
+    }
+  }
+
+  // Asserts the Maven/plugin log shows no attempt to remotely resolve or download the given
+  // (system-scoped) artifact: no "FAILURE/Downloading/Could not ... <artifact>" lines.
+  private def assertNoRemoteResolution(mavenOutput: String, artifact: String): Unit = {
+    val offending = mavenOutput.linesIterator
+      .filter(_.contains(artifact))
+      .filter(l => l.contains("FAILURE") || l.contains("Downloading") || l.contains("Could not"))
+      .toList
+    assert(
+      offending.isEmpty,
+      s"plugin must not remote-resolve system-scoped '$artifact'; offending log lines:\n" +
+        offending.mkString("\n")
+    )
+  }
+
+  @Test
+  def issue27MultiModule() = {
+    // A multi-module reactor where 'lib' declares a system-scoped dependency and 'app'
+    // depends on 'lib'. The whole reactor build must succeed (check() fails if any config
+    // is not produced). Note: Maven does NOT propagate a system-scoped dependency
+    // transitively across modules, so the jar surfaces only on the declaring module ('lib').
+    // A true external dependency-of-dependency behaves the same — the consumer never sees
+    // the system artifact in its resolved artifacts — so the meaningful unit of behavior is
+    // the declaring module.
+    checkWithOutput(
+      "issue_27_multimodule/pom.xml",
+      submodules = List("issue_27_multimodule/lib/pom.xml", "issue_27_multimodule/app/pom.xml")
+    ) {
+      case (_, _, List(libConfig, appConfig), mavenOutput) =>
+        // The plugin must not attempt to remotely resolve/download the system-scoped artifact.
+        assertNoRemoteResolution(mavenOutput, "fake-system-lib")
+
+        // lib declares the system dep: it must be on lib's classpath and resolution modules,
+        // pointing at the provided systemPath jar rather than a remote download.
+        assert(
+          hasCompileClasspathEntryName(libConfig, "jrt-fs.jar"),
+          "lib should have the system-scoped jar (jrt-fs.jar) on its compile classpath"
+        )
+        val libSystemModule =
+          libConfig.project.resolution.toList.flatMap(_.modules).find(_.name == "fake-system-lib")
+        assert(
+          libSystemModule.exists(_.artifacts.exists(_.path.toString.endsWith("jrt-fs.jar"))),
+          "lib's system-scoped module must point at the provided systemPath jar"
+        )
+
+        // app only depends on lib: per Maven's non-transitive system scope, the system jar
+        // does not reach app. Asserting this documents the real (correct) behavior.
+        assert(
+          !hasCompileClasspathEntryName(appConfig, "jrt-fs.jar"),
+          "system-scoped dep must not propagate transitively onto the consumer's classpath"
+        )
+      case _ =>
+        fail("issue_27_multimodule should have exactly two submodules")
     }
   }
 }


### PR DESCRIPTION
**Fixes #27**

## Problem

When a dependency has `<scope>system</scope>` (with a `<systemPath>`), the plugin tried to resolve it from remote Maven repositories. Since system-scoped jars live on the local filesystem and aren't published to any repo, this produced spurious `Downloading from central: …` attempts and `[ERROR] FAILURE …:system` / `Could not resolve …:system` log lines — the symptom reported in #27 (e.g. `jdk.tools:jdk.tools:1.8` pulled in transitively by `hadoop-annotations` on Java 8).

## Fix

In `MojoImplementation`, when building the resolution modules, branch on scope: for `Artifact.SCOPE_SYSTEM`, use the file Maven already set from `<systemPath>` instead of issuing a remote `ArtifactRequest`. If that file is genuinely absent (e.g. `tools.jar` on JDK 11+), the artifact is skipped with a warning rather than aborting the whole `bloopInstall` (the dependency was never resolvable anyway). The compile/runtime classpath is unaffected — it still comes from Maven's own `getCompileClasspathElements()`, which already includes the system jar for the module that declares it.

## Notes

- System scope is **not transitive** in Maven, so a system dep only surfaces on the module that declares it — never on downstream consumers. The fix and tests reflect this.
- The pre-existing `try/catch` in `resolveArtifact` already prevented a hard crash by swallowing the failed remote fetch; this change removes the wasted remote round-trips and the misleading error logging, and uses the provided path as intended.
